### PR TITLE
Create build-gui_mac_no_signed.yml

### DIFF
--- a/.github/workflows/build-gui_mac_no_signed.yml
+++ b/.github/workflows/build-gui_mac_no_signed.yml
@@ -1,0 +1,80 @@
+name: MacOS GUI No Sighed
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+      - v2.2x
+    paths:
+      - '.github/workflows/build-gui_mac_no_signed.yml'
+      - 'gui/src/**'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-gui_mac_no_signed.yml'
+      - 'gui/src/**'
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Select XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          aqtversion: '==3.1.*'
+          version: '6.4.1'
+          modules: 'qtserialport'
+
+      - name: Generate Icons
+        working-directory: ${{github.workspace}}
+        run: |
+          cd gui/src/images
+          bash -x svg2icns.bash IconFile.png
+
+      - name: Build
+        working-directory: ${{github.workspace}}
+        run: |
+          cd gui/src
+          ls
+          qmake HeadTracker.pro
+          make
+
+      - name: prepare output
+        working-directory: ${{github.workspace}}
+        run: |
+          mkdir output
+          cp -R gui/src/HeadTracker.app output/HeadTracker.app
+          # cp gui/src/css/stylesheet.css output/HeadTracker.app/Contents/MacOs
+          # cp gui/src/css/Background.svg output/HeadTracker.app/Contents/MacOs
+
+      - name: Create DMG
+        working-directory: ${{github.workspace}}/output
+        run: |
+          macdeployqt HeadTracker.app -dmg
+          mkdir dmg
+          mv HeadTracker.dmg dmg/HeadTracker.dmg
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: HeadTracker_macOS
+          path: ${{github.workspace}}/output/dmg
+          retention-days: 90


### PR DESCRIPTION
Add a Mac Gui build without signed by apple account.

It may show that `the app is demaged` or `no signed` on macOS, but at least there is a macOS build available.

Users can use this app to sign the app themselves https://github.com/alienator88/Sentinel